### PR TITLE
[ODH-1451] Hotfix for Spark jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM smartislav/spark:2.2.0-12
+FROM smartislav/spark:2.2.1-1
 
 RUN pip install nose nose-exclude coverage \
  && mkdir -p /odh/python/.xunit-reports /odh/python/.coverage-reports

--- a/src/common/basic_analytics/aggregations.py
+++ b/src/common/basic_analytics/aggregations.py
@@ -6,7 +6,7 @@ Aggregation class defines common methods for all aggregations.
 import re
 from abc import ABCMeta, abstractmethod
 
-from pyspark.sql.functions import lit, avg, count, col, regexp_replace, concat
+from pyspark.sql.functions import lit, avg, count, col, regexp_replace
 from pyspark.sql.functions import window, concat_ws, approx_count_distinct
 from pyspark.sql.types import DecimalType
 

--- a/src/common/basic_analytics/aggregations.py
+++ b/src/common/basic_analytics/aggregations.py
@@ -32,15 +32,16 @@ class Aggregation(object):
         metric_name = self.__construct_metric_name()
         window_aggreagated_df = input_dataframe.groupBy(window(time_column, actual_window), *self.__group_fields)
         return self.aggregate(window_aggreagated_df) \
-            .withColumn("metric_name", metric_name) \
-            .withColumn("metric_name", regexp_replace(col("metric_name"), "\\s+", "_"))
+            .withColumn("metric_name", regexp_replace(metric_name, "\\s+", "_"))
 
     def __construct_metric_name(self):
-        metric_name_parts = \
-            [lit(self.__aggregation_name)] + \
-            [concat(lit(group_field + "."), col(group_field))
-             for group_field in self.__group_fields] + \
-            [lit(self._aggregation_field), lit(self.__convert_to_underlined(self.__class__.__name__))]
+        metric_name_parts = [lit(self.__aggregation_name)]
+
+        for group_field in self.__group_fields:
+            metric_name_parts += [lit(group_field), col(group_field)]
+
+        metric_name_parts += [lit(self._aggregation_field),
+                              lit(self.__convert_to_underlined(self.__class__.__name__))]
 
         return concat_ws(".", *metric_name_parts)
 


### PR DESCRIPTION
Due to the bug [`SPARK-21696`](https://issues.apache.org/jira/browse/SPARK-21696) in Apache Spark, it had been updated to version 2.2.1. The function for metric names generating was rewritten because code-generation fails with Spark 2.2.1 without this changes.